### PR TITLE
修复在Link多的情况下（大于10个），页面滚动卡顿的问题

### DIFF
--- a/src/ScrollLink.jsx
+++ b/src/ScrollLink.jsx
@@ -107,9 +107,11 @@ class ScrollLink extends React.Component {
         this.props.onFocus.call(this, obj);
         this.props.onFocus.only = true;
       }
-      this.setState({
-        active: true,
-      });
+      if (this.state.active !== true) {
+        this.setState({
+          active: true,
+        });
+      }
     } else {
       if (this.props.onFocus.only) {
         const obj = {
@@ -119,9 +121,11 @@ class ScrollLink extends React.Component {
         this.props.onBlur.call(this, obj);
       }
       this.props.onFocus.only = false;
-      this.setState({
-        active: false,
-      });
+      if (this.state.active !== false) {
+        this.setState({
+          active: false,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
由于在滚动的时候scrollEventListener一直被触发，考虑到效率问题，应该在需要更新state的时候再更新，不然会不停的刷新引起卡顿现象（13寸的mac可能还不明显，特别是在15寸，或者其他更大显示器的时候，加载10几个Link的时候会有很明显的效率问题）