### PR TITLE
Add an offset property

### DIFF
--- a/examples/link.js
+++ b/examples/link.js
@@ -43,12 +43,12 @@ class Demo extends React.Component {
           <p>Ant Motion</p>
         </div>
         <div className="nav-wap">
-          <Link className="nav-list" location="page0"
+          <Link className="nav-list" location="page0" offset={-58}
             onFocus={this.onFocus.bind(this)}
           >
             Example
           </Link>
-          <Link className="nav-list" location="page1"
+          <Link className="nav-list" location="page1" offset={-58}
             onFocus={this.onFocus.bind(this)}
           >
             Example2

--- a/src/ScrollLink.jsx
+++ b/src/ScrollLink.jsx
@@ -50,7 +50,7 @@ class ScrollLink extends React.Component {
     const elementDom = mapped.get(this.props.location);
     const elementRect = elementDom.getBoundingClientRect();
     this.scrollTop = currentScrollTop();
-    const toTop = Math.round(elementRect.top) - Math.round(docRect.top);
+    const toTop = Math.round(elementRect.top) - Math.round(docRect.top) + Math.round(this.props.offset?this.props.offset:0);
     this.toTop = this.props.toShowHeight ?
     toTop - transformArguments(this.props.showHeightActive)[0] : toTop;
     this.initTime = Date.now();


### PR DESCRIPTION
A fixed header will hide the top part of your content when you click on the link, so I think we need an offset option to make the scrolling function to be more correct.