### PR TITLE
fix(prop-types): allow for react element type

### DIFF
--- a/src/ScrollElement.jsx
+++ b/src/ScrollElement.jsx
@@ -86,7 +86,7 @@ class ScrollElement extends React.Component {
 }
 
 ScrollElement.propTypes = {
-  component: PropTypes.any,
+  component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   playScale: PropTypes.any,
   id: PropTypes.string,
   onChange: PropTypes.func,

--- a/src/ScrollLink.jsx
+++ b/src/ScrollLink.jsx
@@ -189,7 +189,7 @@ class ScrollLink extends React.Component {
 }
 
 ScrollLink.propTypes = {
-  component: PropTypes.string,
+  component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   children: PropTypes.any,
   className: PropTypes.string,
   style: PropTypes.any,

--- a/src/ScrollOverPack.jsx
+++ b/src/ScrollOverPack.jsx
@@ -83,7 +83,7 @@ class ScrollOverPack extends ScrollElement {
   }
 }
 ScrollOverPack.propTypes = {
-  component: PropTypes.string,
+  component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   playScale: PropTypes.any,
   always: PropTypes.bool,
   scrollEvent: PropTypes.func,

--- a/src/ScrollParallax.jsx
+++ b/src/ScrollParallax.jsx
@@ -190,7 +190,7 @@ class ScrollParallax extends React.Component {
 }
 
 ScrollParallax.propTypes = {
-  component: PropTypes.string,
+  component: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   animation: PropTypes.any,
   always: PropTypes.bool,
   location: PropTypes.string,


### PR DESCRIPTION
Currently, it already works with react element, so this PR update the prop-types of `component` props.

```js
const Component = () => ...

<ScrollParallax component="span" ... >
<ScrollParallax component={Component} ... >
```